### PR TITLE
Create cli with c++ based on old c# code

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,0 +1,4 @@
+/build/
+/out/
+/.vs/
+CMakeSettings.json

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.0.0)
+project(ScreenAutoRotate VERSION 0.1.0)
+
+include(CTest)
+enable_testing()
+
+add_executable(ScreenAutoRotate cli.cpp display.cpp)
+
+set(CPACK_PROJECT_NAME ${PROJECT_NAME})
+set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
+include(CPack)

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.0.0)
 project(ScreenAutoRotate VERSION 0.1.0)
 
-include(CTest)
-enable_testing()
-
 add_executable(ScreenAutoRotate cli.cpp display.cpp)
 
 set(CPACK_PROJECT_NAME ${PROJECT_NAME})

--- a/cli/cli.cpp
+++ b/cli/cli.cpp
@@ -27,79 +27,74 @@ void help() {
 
 int rotate(int argc, char** argv) {
     if (argc < 3) {
-        std::cout << "Missing angle, use argument /? for further help\n";
+        std::cerr << "missing angle, use argument /? for further help\n";
         return 1;
     }
 
-    int disp{};
-    if (argc < 4) {
-        disp = 0;
-    } else {
+    int disp{0};
+    if (argc >= 4) {
         try {
             disp = { std::stoi(argv[3]) - 1 };
         } catch (const std::invalid_argument &ex) {
-            std::cout << "Invalid display number, use argument /? for further help\n";
+            std::cerr << "invalid display number, use argument /? for further help\n";
             return 1;
         }
     }
     
     try {
         Display d{ disp };
-        DisplayRotation rot{(std::stoi(argv[2]) / 90) % 4};
-        if (rot == cw_0) {
+        DisplayRotation rot = static_cast<DisplayRotation>((std::stoi(argv[2]) / 90) % 4);
+        if (rot == DisplayRotation::cw_0) {
             return !d.resetRotation();
         } else {
             return !d.rotate(rot);
         }
     } catch (const std::invalid_argument & ex) {
-        std::cout << "Invalid rotation, use argument /? for further help\n";
+        std::cerr << "invalid rotation, use argument /? for further help\n";
         return 1;
     } catch (const std::runtime_error & ex) {
-        std::cout << ex.what() << ", use argument /? for further help and /i to see current displays\n";
+        std::cerr << ex.what() << ", use argument /? for further help and /i to see current displays\n";
         return 1;
     }
 }
 
 int setPosition(int argc, char** argv) {
     if (argc < 4) {
-        std::cout << "Missing coords, use argument /? for further help\n";
+        std::cerr << "missing coords, use argument /? for further help\n";
         return 1;
     }
 
     int disp{0};
-    if (argc < 5) {
-        disp = { 0 };
-    }
-    else {
+    if (argc >= 5) {
         try {
             disp = { std::stoi(argv[4]) - 1 };
         }
         catch (const std::invalid_argument &ex) {
-            std::cout << "Invalid display number, use argument /? for further help\n";
+            std::cerr << "invalid display number, use argument /? for further help\n";
             return 1;
         }
     }
 
     try {
         Display d{ disp };
-        long x{ std::stoi(argv[2]) };
-        long y{ std::stoi(argv[3]) };
+        int x{ std::stoi(argv[2]) };
+        int y{ std::stoi(argv[3]) };
         return !d.setPos(x, y);
     }
     catch (const std::invalid_argument &ex) {
-        std::cout << "Invalid coordinates, use argument /? for further help\n";
+        std::cerr << "invalid coordinates, use argument /? for further help\n";
         return 1;
     }
     catch (const std::runtime_error &ex) {
-        std::cout << ex.what() << ", use argument /? for further help and /i to see current displays\n";
+        std::cerr << ex.what() << ", use argument /? for further help and /i to see current displays\n";
         return 1;
     }
 }
 
 void printInfo(int disp) {
     Display d{ disp };
-    std::cout << "[" << disp << "] " << d.getName() << ":\n";
-    int rot{ d.getRotation() * 90 };
+    std::cout << "[" << (disp + 1) << "] " << d.getName() << ":\n";
+    int rot{ static_cast<int>(d.getRotation()) * 90 };
     std::cout << "  Rotation: " << rot << " deg (clockwise)\n";
     std::cout << "  Position: (" << d.getPosX() << ", " << d.getPosY() <<")\n";
     std::cout << "\n";
@@ -121,7 +116,7 @@ int info(int argc, char** argv) {
             return 0;
         }
         catch (const std::invalid_argument & ex) {
-            std::cout << "Invalid display number, use argument /? for further help\n";
+            std::cerr << "invalid display number, use argument /? for further help\n";
             return 1;
         }
     }
@@ -143,7 +138,7 @@ int main(int argc, char** argv) {
     } else if (mode.compare("info") == 0 || mode.compare("/i") == 0) {
         return info(argc, argv);
     } else {
-        help();
+        std::cerr << "unknown argument, use /? for further help\n";
         return 1;
     }
 }

--- a/cli/cli.cpp
+++ b/cli/cli.cpp
@@ -1,0 +1,150 @@
+#include <iostream>
+#include <string>
+#include <exception>
+#include <stdexcept>
+#include "display.h"
+
+void help() {
+    std::cout << "Rotate and rearrange displays\n";
+    std::cout << "\n";
+    std::cout << "Arguments:\n";
+    std::cout << "\n";
+    std::cout << "  No args     Show this help, same as /?.\n";
+    std::cout << "  /?          Show this help page.\n";
+    std::cout << "  [rotate | /r] [angle] [display]\n";
+    std::cout << "              Rotate the display with the given number clockwise by the given angle.\n";
+    std::cout << "              The angle a must be a multiple of 90 (or 0 to reset any rotation).\n";
+    std::cout << "  [position | /p] [x] [y] [display]\n";
+    std::cout << "              Rearrange the display with the given number to the given coordinates.\n";
+    std::cout << "              Display must be at least 1 and angle a multiple of 90 (or 0 to reset).\n";
+    std::cout << "  [info | /i] [display]\n";
+    std::cout << "              Display information such as name, orientation and position of displays.\n";
+    std::cout << "              If display argument is not speicfied it shows the info for all displays.\n";
+    std::cout << "\n";
+    std::cout << "Display numbers for all arguments start with 1. \n";
+    std::cout << "Unless otherwise specified display argument may be left out with default value of 1.\n";
+    std::cout << "\n";
+}
+
+int rotate(int argc, char** argv) {
+    if (argc < 3) {
+        std::cout << "Missing angle, use argument /? for further help\n";
+        return 1;
+    }
+
+    int disp;
+    if (argc < 4) {
+        disp = { 0 };
+    } else {
+        try {
+            disp = { std::stoi(argv[3]) - 1 };
+        } catch (const std::invalid_argument &ex) {
+            std::cout << "Invalid display number, use argument /? for further help\n";
+            return 1;
+        }
+    }
+    
+    try {
+        Display d{ disp };
+        DisplayRotation rot = static_cast<DisplayRotation>((std::stoi(argv[2]) / 90) % 4);
+        if (rot == cw_0) {
+            return !d.resetRotation();
+        } else {
+            return !d.rotate(rot);
+        }
+    } catch (const std::invalid_argument & ex) {
+        std::cout << "Invalid rotation, use argument /? for further help\n";
+        return 1;
+    } catch (const std::runtime_error & ex) {
+        std::cout << ex.what() << ", use argument /? for further help and /i to see current displays\n";
+        return 1;
+    }
+}
+
+int setPosition(int argc, char** argv) {
+    if (argc < 4) {
+        std::cout << "Missing coords, use argument /? for further help\n";
+        return 1;
+    }
+
+    int disp;
+    if (argc < 5) {
+        disp = { 0 };
+    }
+    else {
+        try {
+            disp = { std::stoi(argv[4]) - 1 };
+        }
+        catch (const std::invalid_argument &ex) {
+            std::cout << "Invalid display number, use argument /? for further help\n";
+            return 1;
+        }
+    }
+
+    try {
+        Display d{ disp };
+        long x{ std::stoi(argv[2]) };
+        long y{ std::stoi(argv[3]) };
+        return !d.setPos(x, y);
+    }
+    catch (const std::invalid_argument &ex) {
+        std::cout << "Invalid coordinates, use argument /? for further help\n";
+        return 1;
+    }
+    catch (const std::runtime_error &ex) {
+        std::cout << ex.what() << ", use argument /? for further help and /i to see current displays\n";
+        return 1;
+    }
+}
+
+void printInfo(int disp) {
+    Display d{ disp };
+    std::cout << "[" << disp << "] " << d.getName() << ":\n";
+    int rot{ d.getRotation() * 90 };
+    std::cout << "  Rotation: " << rot << " deg (clockwise)\n";
+    std::cout << "  Position: (" << d.getPosX() << ", " << d.getPosY() <<")\n";
+    std::cout << "\n";
+}
+
+int info(int argc, char** argv) {
+    if (argc < 3) {
+        int count{ displayCount() };
+        std::cout << count << " displays found:\n";
+        for (int i{ 0 }; i < count; i++) {
+            std::cout << "\n";
+            printInfo(i);
+        }
+        return 0;
+    } else {
+        try {
+            int disp { std::stoi(argv[2]) - 1 };
+            printInfo(disp);
+            return 0;
+        }
+        catch (const std::invalid_argument & ex) {
+            std::cout << "Invalid display number, use argument /? for further help\n";
+            return 1;
+        }
+    }
+}
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        help();
+        return 0;
+    }
+    std::string mode = argv[1];
+    if (mode.compare("/?") == 0) {
+        help();
+        return 0;
+    } else if (mode.compare("rotate") == 0 || mode.compare("/r") == 0) {
+        return rotate(argc, argv);
+    } else if (mode.compare("position") == 0 || mode.compare("/p") == 0) {
+        return setPosition(argc, argv);
+    } else if (mode.compare("info") == 0 || mode.compare("/i") == 0) {
+        return info(argc, argv);
+    } else {
+        help();
+        return 1;
+    }
+}

--- a/cli/cli.cpp
+++ b/cli/cli.cpp
@@ -16,7 +16,6 @@ void help() {
     std::cout << "              The angle a must be a multiple of 90 (or 0 to reset any rotation).\n";
     std::cout << "  [position | /p] [x] [y] [display]\n";
     std::cout << "              Rearrange the display with the given number to the given coordinates.\n";
-    std::cout << "              Display must be at least 1 and angle a multiple of 90 (or 0 to reset).\n";
     std::cout << "  [info | /i] [display]\n";
     std::cout << "              Display information such as name, orientation and position of displays.\n";
     std::cout << "              If display argument is not speicfied it shows the info for all displays.\n";
@@ -32,9 +31,9 @@ int rotate(int argc, char** argv) {
         return 1;
     }
 
-    int disp;
+    int disp{};
     if (argc < 4) {
-        disp = { 0 };
+        disp = 0;
     } else {
         try {
             disp = { std::stoi(argv[3]) - 1 };
@@ -46,7 +45,7 @@ int rotate(int argc, char** argv) {
     
     try {
         Display d{ disp };
-        DisplayRotation rot = static_cast<DisplayRotation>((std::stoi(argv[2]) / 90) % 4);
+        DisplayRotation rot{(std::stoi(argv[2]) / 90) % 4};
         if (rot == cw_0) {
             return !d.resetRotation();
         } else {
@@ -67,7 +66,7 @@ int setPosition(int argc, char** argv) {
         return 1;
     }
 
-    int disp;
+    int disp{0};
     if (argc < 5) {
         disp = { 0 };
     }
@@ -133,7 +132,7 @@ int main(int argc, char** argv) {
         help();
         return 0;
     }
-    std::string mode = argv[1];
+    std::string mode{argv[1]};
     if (mode.compare("/?") == 0) {
         help();
         return 0;

--- a/cli/display.cpp
+++ b/cli/display.cpp
@@ -4,9 +4,9 @@
 #include "display.h"
 
 const int displayCount() {
-    int i = 0;
-    while (1) {
-        DEVMODE dm;
+    int i{0};
+    while (true) {
+        DEVMODE dm{};
         DISPLAY_DEVICE dd;
         dd.cb = { sizeof(DISPLAY_DEVICE) };
         if (!EnumDisplayDevices(NULL, i++, &dd, 0) 
@@ -22,13 +22,13 @@ Display::Display(int device) {
         throw std::runtime_error("could not enum display device " + std::to_string(device));
     }
     if (!EnumDisplaySettings(d.DeviceName, ENUM_CURRENT_SETTINGS, &devmode)) {
-        throw std::runtime_error("could not enum display settings for " + std::string(d.DeviceName));
+        throw std::runtime_error("could not enum display settings for " + std::string{d.DeviceName});
     }
 }
 
 const std::string Display::getName()
 {
-    return std::string(d.DeviceName);
+    return std::string{d.DeviceName};
 }
 
 const long Display::getPosX() {
@@ -44,9 +44,9 @@ const DisplayRotation Display::getRotation() {
 }
 
 bool Display::rotate(const DisplayRotation rotation) {
-    int oldRot = devmode.dmDisplayOrientation;
+    int oldRot{devmode.dmDisplayOrientation};
     int newRot{ (oldRot + rotation) % 4 };
-    if (newRot % 2 != oldRot % 2) {
+    if ((newRot % 2) != (oldRot % 2)) {
         int temp = devmode.dmPelsHeight;
         devmode.dmPelsHeight = devmode.dmPelsWidth;
         devmode.dmPelsWidth = temp;
@@ -56,8 +56,8 @@ bool Display::rotate(const DisplayRotation rotation) {
 }
 
 bool Display::resetRotation() {
-    if (devmode.dmDisplayOrientation % 2 != 0) {
-        int temp = devmode.dmPelsHeight;
+    if ((devmode.dmDisplayOrientation % 2) != 0) {
+        int temp{devmode.dmPelsHeight};
         devmode.dmPelsHeight = devmode.dmPelsWidth;
         devmode.dmPelsWidth = temp;
     }

--- a/cli/display.cpp
+++ b/cli/display.cpp
@@ -1,0 +1,72 @@
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include "display.h"
+
+const int displayCount() {
+    int i = 0;
+    while (1) {
+        DEVMODE dm;
+        DISPLAY_DEVICE dd;
+        dd.cb = { sizeof(DISPLAY_DEVICE) };
+        if (!EnumDisplayDevices(NULL, i++, &dd, 0) 
+                || !EnumDisplaySettings(dd.DeviceName, ENUM_CURRENT_SETTINGS, &dm)) {
+            return i - 1;
+        }
+    }
+}
+
+Display::Display(int device) {
+    d.cb = { sizeof(DISPLAY_DEVICE) };
+    if (!EnumDisplayDevices(NULL, device, &d, 0)) {
+        throw std::runtime_error("could not enum display device " + std::to_string(device));
+    }
+    if (!EnumDisplaySettings(d.DeviceName, ENUM_CURRENT_SETTINGS, &devmode)) {
+        throw std::runtime_error("could not enum display settings for " + std::string(d.DeviceName));
+    }
+}
+
+const std::string Display::getName()
+{
+    return std::string(d.DeviceName);
+}
+
+const long Display::getPosX() {
+    return devmode.dmPosition.x;
+}
+
+const long Display::getPosY() {
+    return devmode.dmPosition.y;
+}
+
+const DisplayRotation Display::getRotation() {
+    return static_cast<DisplayRotation>(devmode.dmDisplayOrientation);
+}
+
+bool Display::rotate(const DisplayRotation rotation) {
+    int oldRot = devmode.dmDisplayOrientation;
+    int newRot{ (oldRot + rotation) % 4 };
+    if (newRot % 2 != oldRot % 2) {
+        int temp = devmode.dmPelsHeight;
+        devmode.dmPelsHeight = devmode.dmPelsWidth;
+        devmode.dmPelsWidth = temp;
+    }
+    devmode.dmDisplayOrientation = newRot;
+    return ChangeDisplaySettingsEx(d.DeviceName, &devmode, NULL, CDS_UPDATEREGISTRY, NULL) != 0;
+}
+
+bool Display::resetRotation() {
+    if (devmode.dmDisplayOrientation % 2 != 0) {
+        int temp = devmode.dmPelsHeight;
+        devmode.dmPelsHeight = devmode.dmPelsWidth;
+        devmode.dmPelsWidth = temp;
+    }
+    devmode.dmDisplayOrientation = { 0 };
+    return ChangeDisplaySettingsEx(d.DeviceName, &devmode, NULL, CDS_UPDATEREGISTRY, NULL) != 0;
+}
+
+bool Display::setPos(const long x, const long y) {
+    devmode.dmPosition.x = { x };
+    devmode.dmPosition.y = { y };
+    return ChangeDisplaySettingsEx(d.DeviceName, &devmode, NULL, CDS_UPDATEREGISTRY, NULL) != 0;
+}

--- a/cli/display.cpp
+++ b/cli/display.cpp
@@ -3,13 +3,13 @@
 #include <string>
 #include "display.h"
 
-const int displayCount() {
+int displayCount() {
     int i{0};
     while (true) {
         DEVMODE dm{};
-        DISPLAY_DEVICE dd;
+        DISPLAY_DEVICE dd{};
         dd.cb = { sizeof(DISPLAY_DEVICE) };
-        if (!EnumDisplayDevices(NULL, i++, &dd, 0) 
+        if (!EnumDisplayDevices(nullptr, i++, &dd, 0) 
                 || !EnumDisplaySettings(dd.DeviceName, ENUM_CURRENT_SETTINGS, &dm)) {
             return i - 1;
         }
@@ -17,56 +17,55 @@ const int displayCount() {
 }
 
 Display::Display(int device) {
-    d.cb = { sizeof(DISPLAY_DEVICE) };
-    if (!EnumDisplayDevices(NULL, device, &d, 0)) {
+    display.cb = { sizeof(DISPLAY_DEVICE) };
+    if (!EnumDisplayDevices(nullptr, device, &display, 0)) {
         throw std::runtime_error("could not enum display device " + std::to_string(device));
     }
-    if (!EnumDisplaySettings(d.DeviceName, ENUM_CURRENT_SETTINGS, &devmode)) {
-        throw std::runtime_error("could not enum display settings for " + std::string{d.DeviceName});
+    if (!EnumDisplaySettings(display.DeviceName, ENUM_CURRENT_SETTINGS, &devmode)) {
+        throw std::runtime_error("could not enum display settings for " + std::string{ display.DeviceName });
     }
 }
 
-const std::string Display::getName()
-{
-    return std::string{d.DeviceName};
+const std::string Display::getName() const {
+    return std::string{ display.DeviceName };
 }
 
-const long Display::getPosX() {
+long Display::getPosX() const {
     return devmode.dmPosition.x;
 }
 
-const long Display::getPosY() {
+long Display::getPosY() const {
     return devmode.dmPosition.y;
 }
 
-const DisplayRotation Display::getRotation() {
+const DisplayRotation Display::getRotation() const {
     return static_cast<DisplayRotation>(devmode.dmDisplayOrientation);
 }
 
 bool Display::rotate(const DisplayRotation rotation) {
-    int oldRot{devmode.dmDisplayOrientation};
-    int newRot{ (oldRot + rotation) % 4 };
+    int oldRot{ static_cast<int>(devmode.dmDisplayOrientation) };
+    int newRot{ (oldRot + static_cast<int>(rotation)) % 4 };
     if ((newRot % 2) != (oldRot % 2)) {
         int temp = devmode.dmPelsHeight;
         devmode.dmPelsHeight = devmode.dmPelsWidth;
         devmode.dmPelsWidth = temp;
     }
     devmode.dmDisplayOrientation = newRot;
-    return ChangeDisplaySettingsEx(d.DeviceName, &devmode, NULL, CDS_UPDATEREGISTRY, NULL) != 0;
+    return ChangeDisplaySettingsEx(display.DeviceName, &devmode, nullptr, CDS_UPDATEREGISTRY, nullptr) != 0;
 }
 
 bool Display::resetRotation() {
     if ((devmode.dmDisplayOrientation % 2) != 0) {
-        int temp{devmode.dmPelsHeight};
+        int temp{ static_cast<int>(devmode.dmPelsHeight) };
         devmode.dmPelsHeight = devmode.dmPelsWidth;
         devmode.dmPelsWidth = temp;
     }
     devmode.dmDisplayOrientation = { 0 };
-    return ChangeDisplaySettingsEx(d.DeviceName, &devmode, NULL, CDS_UPDATEREGISTRY, NULL) != 0;
+    return ChangeDisplaySettingsEx(display.DeviceName, &devmode, nullptr, CDS_UPDATEREGISTRY, nullptr) != 0;
 }
 
 bool Display::setPos(const long x, const long y) {
     devmode.dmPosition.x = { x };
     devmode.dmPosition.y = { y };
-    return ChangeDisplaySettingsEx(d.DeviceName, &devmode, NULL, CDS_UPDATEREGISTRY, NULL) != 0;
+    return ChangeDisplaySettingsEx(display.DeviceName, &devmode, nullptr, CDS_UPDATEREGISTRY, nullptr) != 0;
 }

--- a/cli/display.h
+++ b/cli/display.h
@@ -3,25 +3,25 @@
 #include <string>
 #include <Windows.h>
 
-enum DisplayRotation { cw_0, cw_90, cw_180, cw_270 };
+enum class DisplayRotation : std::uint8_t { cw_0, cw_90, cw_180, cw_270 };
 
 const int displayCount();
 
 class Display {
 private:
     DEVMODE devmode;
-    DISPLAY_DEVICE d;
+    DISPLAY_DEVICE display{};
 
 public:
     Display(const int device);
 
-    const std::string getName();
+    const std::string getName() const;
 
-    const long getPosX();
+    const long getPosX() const;
 
-    const long getPosY();
+    const long getPosY() const;
 
-    const DisplayRotation getRotation();
+    const DisplayRotation getRotation() const;
     
     bool rotate(const DisplayRotation rotation);
 

--- a/cli/display.h
+++ b/cli/display.h
@@ -3,13 +3,13 @@
 #include <string>
 #include <Windows.h>
 
-enum class DisplayRotation : std::uint8_t { cw_0, cw_90, cw_180, cw_270 };
+enum class DisplayRotation : int { cw_0, cw_90, cw_180, cw_270 };
 
-const int displayCount();
+int displayCount();
 
 class Display {
 private:
-    DEVMODE devmode;
+    DEVMODE devmode{};
     DISPLAY_DEVICE display{};
 
 public:
@@ -17,9 +17,9 @@ public:
 
     const std::string getName() const;
 
-    const long getPosX() const;
+    long getPosX() const;
 
-    const long getPosY() const;
+    long getPosY() const;
 
     const DisplayRotation getRotation() const;
     

--- a/cli/display.h
+++ b/cli/display.h
@@ -1,0 +1,32 @@
+#ifndef DISPLAY_H
+#define DISPLAY_H
+#include <string>
+#include <Windows.h>
+
+enum DisplayRotation { cw_0, cw_90, cw_180, cw_270 };
+
+const int displayCount();
+
+class Display {
+private:
+    DEVMODE devmode;
+    DISPLAY_DEVICE d;
+
+public:
+    Display(const int device);
+
+    const std::string getName();
+
+    const long getPosX();
+
+    const long getPosY();
+
+    const DisplayRotation getRotation();
+    
+    bool rotate(const DisplayRotation rotation);
+
+    bool resetRotation();
+
+    bool setPos(const long x, const long y);
+};
+#endif


### PR DESCRIPTION
This cli written in c++ will be a way easier and cleaner way to rotate and rearrange displays than the old c#code.  
It builds a base that can later be integrated into a graphical application or combined with an arduino for auto rotation.  
An additional benefit is that it also can be used as stand-alone command line tool if desired or integrated with makro solutions like autohotkey or the stream deck.  

## Usage
```
Rotate and rearrange displays

Arguments:

  No args     Show this help, same as /?.
  /?          Show this help page.
  [rotate | /r] [angle] [display]
              Rotate the display with the given number clockwise by the given angle.
              The angle a must be a multiple of 90 (or 0 to reset any rotation).
  [position | /p] [x] [y] [display]
              Rearrange the display with the given number to the given coordinates.
              Display must be at least 1 and angle a multiple of 90 (or 0 to reset).
  [info | /i] [display]
              Display information such as name, orientation and position of displays.
              If display argument is not speicfied it shows the info for all displays.

Display numbers for all arguments start with 1.
Unless otherwise specified display argument may be left out with default value of 1.
```